### PR TITLE
Now loans page will show mocked data if can't fetch them from server

### DIFF
--- a/src/app/MOD/Dashboard/Pages/loans/loans.component.ts
+++ b/src/app/MOD/Dashboard/Pages/loans/loans.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { LoanService } from './service/loan.service';
 import { TranslateModule } from '@ngx-translate/core';
 import { CommonModule } from '@angular/common';
@@ -9,8 +9,18 @@ import { CommonModule } from '@angular/common';
   standalone: true,
   imports: [TranslateModule, CommonModule],
 })
-export default class LoansComponent {
-  loans$ = this.loanService.getLoans('api/v1/loans');
+export default class LoansComponent implements OnInit {
+  loans$ = this.loanService.getLoans('api/v1/loans'); // This returns Observable<ILoanData[]>
+  ngOnInit(): void {
+    this.loans$.subscribe({
+      next: loans => {
+        console.log('loans fetched');
+        console.log(loans);
+      },
+      error: error => console.error('Error fetching loans:', error),
+      complete: () => console.log('Loan fetch operation completed'),
+    });
+  }
 
   constructor(private loanService: LoanService) {}
 }

--- a/src/app/MOD/Dashboard/Pages/loans/service/loan.service.ts
+++ b/src/app/MOD/Dashboard/Pages/loans/service/loan.service.ts
@@ -1,39 +1,94 @@
 import { Injectable } from '@angular/core';
-import {
-  HttpClient,
-  HttpErrorResponse,
-  HttpHeaders,
-} from '@angular/common/http';
-import { Observable, catchError, throwError } from 'rxjs';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { ILoanData } from '../interface/ILoan';
 import { TokenService } from '@/CORE/Auth/services/token-service.service';
+
 @Injectable({
   providedIn: 'root',
 })
 export class LoanService {
+  private urlBase: string = 'https://api.bancodelapeseta.com';
+  private mockLoans: ILoanData[] = [
+    {
+      id: 1,
+      account: {
+        balance: 10000.0,
+        real_balance: 9500.0,
+        currency: {
+          currency: 'USD',
+        },
+        account_number: '123456789',
+        locked: false,
+      },
+      amount: 5000.0,
+      totalAmount: 5500.0,
+      interestRate: 0.05,
+      initialSubscriptionRate: 0.03,
+      currentSubscriptionRate: 0.03,
+      startDate: '2024-01-01T00:00:00Z',
+      initialFinishDate: '2024-12-31T23:59:59Z',
+      currentFinishDate: '2025-12-31T23:59:59Z',
+      paidAmount: 5500.0,
+      unpaidAmount: 0,
+      pendingAmount: 0,
+      paidSubscriptions: 12,
+    },
+    {
+      id: 2,
+      account: {
+        balance: 15000.0,
+        real_balance: 14000.0,
+        currency: {
+          currency: 'EUR',
+        },
+        account_number: '987654321',
+        locked: false,
+      },
+      amount: 10000.0,
+      totalAmount: 11000.0,
+      interestRate: 0.06,
+      initialSubscriptionRate: 0.04,
+      currentSubscriptionRate: 0.04,
+      startDate: '2023-06-01T00:00:00Z',
+      initialFinishDate: '2024-05-31T23:59:59Z',
+      currentFinishDate: '2025-05-31T23:59:59Z',
+      paidAmount: 4000.0,
+      unpaidAmount: 6000.0,
+      pendingAmount: 6000.0,
+      paidSubscriptions: 12,
+    },
+  ];
+
   constructor(
     private http: HttpClient,
     private tokenInterceptor: TokenService
   ) {}
 
-  urlBase: string = 'https://api.bancodelapeseta.com';
-
   getLoans(uri: string): Observable<ILoanData[]> {
-    const tkn = this.tokenInterceptor.getToken() || '';
+    const tkn = this.tokenInterceptor.getToken() ?? '';
     const headers = new HttpHeaders({
       Authorization: `Bearer ${tkn}`,
     });
 
     return this.http
       .get<ILoanData[]>(`${this.urlBase}/${uri}`, { headers })
-      .pipe(catchError(this.handleError));
-  }
-  private handleError(error: HttpErrorResponse) {
-    if (error.status === 0) {
-      console.log('An error has occurred', error.error);
-    } else {
-      console.log('Backend status code', error.status, error.error);
-    }
-    return throwError(() => new Error('Something failed, try again.'));
+      .pipe(
+        map(response => {
+          // Check if the response is an empty array
+          if (response && response.length === 0) {
+            // Return the mock data instead
+            console.warn('Server response is empty');
+            console.warn('Showing mock data. For demo purposes only.');
+            return this.mockLoans;
+          }
+          return response;
+        }),
+        catchError(error => {
+          console.error('Error fetching loans, returning mock data', error);
+          return of(this.mockLoans); // Fallback to mock data in case of an error
+        })
+      );
   }
 }


### PR DESCRIPTION
# Fix loans list

## Now loans page will show mocked data if can't fetch them from server (for demo purposes)

![image](https://github.com/DSO-TECHINFO/bancodelapeseta-frontend/assets/26280134/5a693c89-f1d0-4678-b64a-9aab2954a83e)

![loans](https://github.com/DSO-TECHINFO/bancodelapeseta-frontend/assets/26280134/fbc43585-dfce-40fa-b823-be2e6fde6348)

Route: ```/dashboard/loans```

## Result running: ```npm ci```

![image](https://github.com/DSO-TECHINFO/bancodelapeseta-frontend/assets/26280134/f6c72bee-78c4-4df3-9f79-545b2b24d9b7)


## Result running: ```npm build```

![image](https://github.com/DSO-TECHINFO/bancodelapeseta-frontend/assets/26280134/acdf7a76-1286-44b1-94de-7d6f32fa906a)




